### PR TITLE
Formatting with Black

### DIFF
--- a/HARK/hark_portfolio_agents.py
+++ b/HARK/hark_portfolio_agents.py
@@ -19,6 +19,7 @@ import yaml
 import json
 import pika
 import uuid
+import time
 
 from abc import ABC, abstractmethod
 
@@ -637,6 +638,7 @@ class ClientRPCMarket(AbstractMarket):
             body=json.dumps(data))
 
         while self.response is None:
+            time.sleep(4)
             self.connection.process_data_events()
 
         self.latest_price = float(self.response)


### PR DESCRIPTION
I was reading about how the Django codebase is now being autoformatted with Black (https://github.com/psf/black) and decided to run `hark_portfolio_agents.py`, our largest and potentially least readable file, through the autoformatter. It definitely made the code look cleaner, though there are a few instances of unnecessary line-breaks which might make the code less readable. Furthermore, black changes all single-quote strings to double quotes, a decision which i personally don't like. It's worth thinking about if we want to make autoformatting a part of our workflow (it can even be automatically applied to a python file upon commit). 