### PR TITLE
Add CalibrationSimulation test

### DIFF
--- a/sharkfin/population.py
+++ b/sharkfin/population.py
@@ -1,6 +1,6 @@
 import HARK.ConsumptionSaving.ConsPortfolioModel as cpm
 import HARK.ConsumptionSaving.ConsIndShockModel as cism
-from utilities import *
+from sharkfin.utilities import *
 import math
 import pandas as pd
 import random

--- a/sharkfin/tests/test_portfolio_agents.py
+++ b/sharkfin/tests/test_portfolio_agents.py
@@ -29,7 +29,7 @@ def test_mock_market():
 #
 #  ror = mock.daily_rate_of_return(buy_sell=(0,0))
 
-def test_simulation():
+def test_attention_simulation():
     '''
     Sets up and runs an agent population simulation
     '''

--- a/sharkfin/tests/test_portfolio_agents.py
+++ b/sharkfin/tests/test_portfolio_agents.py
@@ -1,4 +1,3 @@
-from sharkfin.markets.pnl import MarketPNL
 from sharkfin.markets import MockMarket
 from sharkfin.broker import *
 from sharkfin.expectations import *
@@ -83,3 +82,60 @@ def test_simulation():
     attsim.pop.class_stats()['mNrm_ratio_StE_mean']
 
     attsim.data()['sell_macro']
+
+
+def test_calibration_simulation():
+    '''
+    Sets up and runs an agent population simulation
+    '''
+    dist_params = {
+    'CRRA' : {'bot' : 2, 'top' : 10, 'n' : 2}, # Chosen for "interesting" results
+    'DiscFac' : {'bot' : 0.936, 'top' : 0.978, 'n' : 2} # from CSTW "MPC" results
+    }
+
+    ssvp = sabelhaus_song_var_profile()
+
+    #assume all agents are 27
+    idx_27 = ssvp['Age'].index(27)
+
+    #parameters shared by all agents
+    agent_parameters = {
+        'aNrmInitStd' : 0.0,
+        'LivPrb' : [0.98 ** 0.25],
+        'PermGroFac': [1.01 ** 0.25],
+        'pLvlInitMean' : 1.0, # initial distribution of permanent income
+        'pLvlInitStd' : 0.0,
+        'Rfree' : 1.0,
+        'TranShkStd' : [ssvp['TranShkStd'][idx_27] / 2],  # Adjust non-multiplicative shock to quarterly
+        'PermShkStd' : [ssvp['PermShkStd'][idx_27] ** 0.25]
+    }
+
+    n_per_class = 1
+
+    pop = AgentPopulation(agent_parameters, dist_params, n_per_class)
+    
+    #initialize the financial model
+    fm = FinanceModel()
+    
+    fm.calculate_risky_expectations()
+    agent_parameters.update(fm.risky_expectations())
+    
+    #initialize population model
+    pop.init_simulation()
+
+    # arguments to attention simulation
+    
+    a = 0.2
+    q = 1
+    r = 1
+    market = None
+    
+    sim = CalibrationSimulation(pop, fm, a=a, q=q, r=r, market=market)
+    sim.pad_market(n_days=1)
+    sim.simulate()
+
+    assert(sim.history['buy_sell'][0] == (0, 0))
+    ## testing for existence of this class stat
+    sim.pop.class_stats()['mNrm_ratio_StE_mean']
+
+    sim.data()['sell_macro']


### PR DESCRIPTION
adds a test for the CalibrationSimulation. Similar to the AttentionSimulation test with an added test to see if the padded market adds buy/sell of (0, 0) to the history list.