### PR TITLE
Fix ror and track prices in market

### DIFF
--- a/sharkfin/broker.py
+++ b/sharkfin/broker.py
@@ -57,7 +57,7 @@ class Broker:
         self.buy_sell_macro_history.append(buy_sell_macro)
         # print("Buy/Sell Limit: " + str(buy_sell))
 
-        self.market.run_market(buy_sell=buy_sell, seed=seed)
+        price = self.market.run_market(buy_sell=buy_sell, seed=seed)
 
         # clear the local limits
         self.buy_limit = 0
@@ -66,7 +66,7 @@ class Broker:
         self.buy_orders_macro = 0
         self.sell_orders_macro = 0
 
-        return buy_sell, self.market.daily_rate_of_return()
+        return buy_sell, self.market.daily_rate_of_return(), price
 
     def close(self):
         self.market.close_market()

--- a/sharkfin/markets/ammps.py
+++ b/sharkfin/markets/ammps.py
@@ -11,7 +11,7 @@ import time
 class ClientRPCMarket(AbstractMarket):
     def __init__(self, seed_limit=None, queue_name='', host='localhost'):
         self.simulation_price_scale = 1
-        self.default_sim_price = 400
+        self.default_sim_price = 100
 
         # stuff from MarketPNL that we may or may not need
 
@@ -42,6 +42,7 @@ class ClientRPCMarket(AbstractMarket):
         self.seed_limit = seed_limit
 
         self.latest_price = None
+        self.prices = [self.default_sim_price]
 
         self.rpc_queue_name = queue_name
         self.rpc_host_name = host
@@ -112,6 +113,9 @@ class ClientRPCMarket(AbstractMarket):
         print('response received')
 
         self.latest_price = float(self.response)
+        self.prices.append(float(self.response))
+
+        return self.latest_price
 
     def get_simulation_price(self, seed=0, buy_sell=(0, 0)):
         return self.latest_price
@@ -132,7 +136,8 @@ class ClientRPCMarket(AbstractMarket):
         if last_sim_price is None:
             last_sim_price = self.default_sim_price
 
-        ror = (last_sim_price * self.simulation_price_scale - 100) / 100
+        # ror = (last_sim_price * self.simulation_price_scale - 100) / 100
+        ror = (self.latest_price - self.prices[-2])/self.prices[-2]
 
         # adjust to calibrated NetLogo to S&P500
         # do we need to calibrate AMMPS to S&P as well?

--- a/sharkfin/simulation.py
+++ b/sharkfin/simulation.py
@@ -654,7 +654,7 @@ class AttentionSimulation(BasicSimulation):
                     if random.random() < self.attention_rate:
                         self.broker.transact(self.attend(agent))
 
-                buy_sell, ror = self.broker.trade()
+                buy_sell, ror, price = self.broker.trade()
                 # print("ror: " + str(ror))
 
                 new_run = True
@@ -726,7 +726,7 @@ class CalibrationSimulation(BasicSimulation):
             for agent in self.agents:
                 self.broker.transact(np.zeros(1))
 
-            buy_sell, ror = self.broker.trade()
+            buy_sell, ror, price = self.broker.trade()
                 
             self.update_agent_wealth_capital_gains(self.fm.rap(), ror)
 
@@ -750,7 +750,7 @@ class CalibrationSimulation(BasicSimulation):
         sell = -buy_sell_shock[1]
 
         self.broker.transact(np.array((buy, sell)))
-        buy_sell, ror = self.broker.trade()
+        buy_sell, ror, price = self.broker.trade()
 
         self.update_agent_wealth_capital_gains(self.fm.rap(), ror)
 
@@ -782,8 +782,8 @@ class CalibrationSimulation(BasicSimulation):
         data = None
         try:
             data_dict = {
-                't': range(len(self.fm.prices[1:])),
-                'prices': self.fm.prices[1:],
+                't': range(len(self.broker.market.prices[1:])),
+                'prices': self.broker.market.prices[1:],
                 'buy': [bs[0] for bs in self.broker.buy_sell_history],
                 'sell': [bs[1] for bs in self.broker.buy_sell_history],
                 'ror': self.fm.ror_list,


### PR DESCRIPTION
A hasty fix for #91 which should allow us to run chum sims over the weekend. There might be a better way to architect this. It is also hard to write automated tests for the RPC market, which depends on an external market and RabbitMQ connection.

A potential automated test could ensure that the price list in the market matches the price list in the FinanceModel within a floating point arithmetic error.