### PR TITLE
WIP burn_in feature for all simulations

### DIFF
--- a/sharkfin/markets/__init__.py
+++ b/sharkfin/markets/__init__.py
@@ -21,7 +21,7 @@ class AbstractMarket(ABC):
     @abstractmethod
     def dividends(self):
         """
-        A list of prices, beginning with the default price.
+        A list of dividends, beginning with the default price.
         """
         pass
 

--- a/sharkfin/simulation.py
+++ b/sharkfin/simulation.py
@@ -141,9 +141,11 @@ class BasicSimulation(AbstractSimulation):
         """
         Runs for n_days days with no broker activity.
         Used for warming up the agents in the market.
+
+        Tracking is disabled during the burn-in period.
         """
         for day in range(n_days):
-            start_time = datetime.now()
+            #start_time = datetime.now()
 
             # is this needed for chum?
             for agent in self.pop.agents:
@@ -158,11 +160,10 @@ class BasicSimulation(AbstractSimulation):
             #self.fm.add_ror(ror) 
             self.fm.calculate_risky_expectations()
 
-            end_time = datetime.now()
-
-            time_delta = end_time - start_time
-
-            self.track(day, time_delta = time_delta)
+            # tracking has been disabled. Should it be optional?
+            #end_time = datetime.now()
+            #time_delta = end_time - start_time
+            #self.track(day, time_delta = time_delta)
 
 
     def data(self):
@@ -173,20 +174,20 @@ class BasicSimulation(AbstractSimulation):
         data = None
         
         data_dict = {
-            't': range(len(self.market.prices[1:])),
-            'prices': self.market.prices[1:],
-            'buy': [bs[0] for bs in self.broker.buy_sell_history],
-            'sell': [bs[1] for bs in self.broker.buy_sell_history],
-            'buy_macro': [bs[0] for bs in self.broker.buy_sell_macro_history],
-            'sell_macro': [bs[1] for bs in self.broker.buy_sell_macro_history],
+            't': range(len(self.market.prices[self.burn_in + 1:])),
+            'prices': self.market.prices[self.burn_in + 1:],
+            'buy': [bs[0] for bs in self.broker.buy_sell_history][self.burn_in:],
+            'sell': [bs[1] for bs in self.broker.buy_sell_history][self.burn_in:],
+            'buy_macro': [bs[0] for bs in self.broker.buy_sell_macro_history][self.burn_in:],
+            'sell_macro': [bs[1] for bs in self.broker.buy_sell_macro_history][self.burn_in:],
             'owned': self.history['owned_shares'][1:],
             'total_assets': self.history['total_assets'][1:],
             'mean_income': self.history['mean_income_level'][1:],
             'total_consumption': self.history['total_consumption_level'][1:],
             'permshock_std': self.history['permshock_std'][1:],
-            'ror': self.market.ror_list(),
-            'expected_ror': self.fm.expected_ror_list[1:],
-            'expected_std': self.fm.expected_std_list[1:],
+            'ror': self.market.ror_list()[self.burn_in:],
+            'expected_ror': self.fm.expected_ror_list[self.burn_in + 1:],
+            'expected_std': self.fm.expected_std_list[self.burn_in + 1:],
         }
 
         try:
@@ -258,16 +259,16 @@ class BasicSimulation(AbstractSimulation):
         ax = sns.lineplot(data=data, x='time', y='aLvl_mean', hue='label')
         ax.set_title("mean aLvl by class subpopulation")
 
-    def start_simulation(self):
+    def start_simulation(self, burn_in = None):
         self.start_time = datetime.now()
-
         # Initialize share ownership for agents
         for agent in self.pop.agents:
             agent.shares = self.pop.compute_share_demand(agent, self.market.prices[-1])
 
-        self.track(-1)
+        if burn_in is not None:
+            self.burn_in(burn_in)
 
-        return self.start_time
+        self.burn_in = burn_in if burn_in is not None else 0
 
 
     def simulate(self, quarters=None, start=True, burn_in = None):
@@ -284,10 +285,9 @@ class BasicSimulation(AbstractSimulation):
         """
 
         if start:
-            self.start_simulation()
-
-        if burn_in is not None:
-            self.burn_in(burn_in)
+            self.start_simulation(burn_in)
+        
+        self.track(-1)
 
         if quarters is None:
             quarters = self.quarters_per_simulation
@@ -552,12 +552,12 @@ class AttentionSimulation(BasicSimulation):
         burn_in : int or None
            If not None, then an int number of days with no broker activity to run before starting the simulation.
         """
+        self.start_time = datetime.now()
 
         if start:
-            self.start_simulation()
+            self.start_simulation(burn_in)
 
-        if burn_in is not None:
-            self.burn_in(burn_in)
+        self.track(-1)
 
         if quarters is None:
             quarters = self.quarters_per_simulation
@@ -648,14 +648,16 @@ class CalibrationSimulation(BasicSimulation):
         """
         Workhorse method that runs the simulation.
         """
-        if start:
-            self.start_simulation()
+        self.start_time = datetime.now()
 
-        self.burn_in(burn_in)
+        if start:
+            self.start_simulation(burn_in)
+
+        self.track(-1)
 
         start_time = datetime.now()
 
-        day = burn_in
+        day = burn_in if burn_in is not None else 0
 
         buy = buy_sell_shock[0]
         sell = -buy_sell_shock[1]
@@ -693,13 +695,14 @@ class CalibrationSimulation(BasicSimulation):
         data = None
 
         data_dict = {
-            't': range(len(self.market.prices)),
-            'prices': self.market.prices,
-            'buy': [None] + [bs[0] for bs in self.broker.buy_sell_history],
-            'sell': [None] +  [bs[1] for bs in self.broker.buy_sell_history],
-            'ror': [None] + self.market.ror_list(),
-            'expected_ror': self.fm.expected_ror_list,
-            'expected_std': self.fm.expected_std_list,
+            't': range(len(self.market.prices) - self.burn_in),
+            'prices': self.market.prices[self.burn_in:],
+            'dividends': self.market.dividends[self.burn_in:],
+            'buy': [None] + [bs[0] for bs in self.broker.buy_sell_history][self.burn_in:],
+            'sell': [None] +  [bs[1] for bs in self.broker.buy_sell_history][self.burn_in:],
+            'ror': [None] + self.market.ror_list()[self.burn_in:],
+            'expected_ror': self.fm.expected_ror_list[self.burn_in:],
+            'expected_std': self.fm.expected_std_list[self.burn_in:],
             'market_times': self.history['run_times']
         }
 

--- a/sharkfin/simulation.py
+++ b/sharkfin/simulation.py
@@ -162,7 +162,7 @@ class BasicSimulation(AbstractSimulation):
 
             time_delta = end_time - start_time
 
-            self.track(day, time_delta)
+            self.track(day, time_delta = time_delta)
 
 
     def data(self):
@@ -338,10 +338,11 @@ class BasicSimulation(AbstractSimulation):
 
         self.end_time = datetime.now()
 
-    def track(self, day):
+    def track(self, day, time_delta = 0):
         """
         Tracks the current state of agent's total assets and owned shares
         """
+
         tal = (
             sum([agent.state_now['aLvl'].sum() for agent in self.pop.agents])
             * self.pop.dollars_per_hark_money_unit

--- a/sharkfin/simulation.py
+++ b/sharkfin/simulation.py
@@ -599,19 +599,19 @@ class CalibrationSimulation(BasicSimulation):
 
         self.history['run_times'] = []
 
-    def simulate(self, n_days, start=True, buy_sell_shock=(0, 0)):
-        """
-        Workhorse method that runs the simulation.
-        """
+    def start_simulation(self):
         self.start_time = datetime.now()
 
         # Initialize share ownership for agents
-        if start:
-            for agent in self.pop.agents:
-                agent.shares = self.pop.compute_share_demand(agent, self.market.prices[-1])
+        for agent in self.pop.agents:
+            agent.shares = self.pop.compute_share_demand(agent, self.market.prices[-1])
 
         self.track(-1, 0)
 
+        return self.start_time
+
+
+    def burn_in(self, n_days):
         for day in range(n_days):
             start_time = datetime.now()
 
@@ -635,9 +635,18 @@ class CalibrationSimulation(BasicSimulation):
             self.track(day, time_delta)
 
 
+    def simulate(self, start=True, buy_sell_shock=(0, 0), burn_in = 0):
+        """
+        Workhorse method that runs the simulation.
+        """
+        if start:
+            self.start_simulation()
 
-        # last day shock
+        self.burn_in(burn_in)
+
         start_time = datetime.now()
+
+        day = burn_in
 
         buy = buy_sell_shock[0]
         sell = -buy_sell_shock[1]

--- a/sharkfin/tests/test_simulation.py
+++ b/sharkfin/tests/test_simulation.py
@@ -51,7 +51,7 @@ def test_calibration_simulation():
     market = None
 
     sim = CalibrationSimulation(pop, FinanceModel, q=q, r=r, market=market)
-    sim.simulate(n_days=2, buy_sell_shock=(200, 600))
+    sim.simulate(burn_in=2, buy_sell_shock=(200, 600))
 
     assert sim.broker.buy_sell_history[1] == (0, 0)
     # assert(len(sim.history['buy_sell']) == 3) # need the padded day

--- a/sharkfin/tests/test_simulation.py
+++ b/sharkfin/tests/test_simulation.py
@@ -57,7 +57,7 @@ def test_calibration_simulation():
     # assert(len(sim.history['buy_sell']) == 3) # need the padded day
     data = sim.data()
 
-    assert len(data["prices"]) == 4
+    assert len(data["prices"]) == 2
 
 
 def test_attention_simulation():
@@ -99,7 +99,7 @@ def test_attention_simulation():
         market=market,
         days_per_quarter=days_per_quarter,
     )
-    attsim.simulate()
+    attsim.simulate(burn_in=20)
 
     ## testing for existence of this class stat
     attsim.pop.class_stats()["mNrm_ratio_StE_mean"]
@@ -110,3 +110,7 @@ def test_attention_simulation():
 
     assert attsim.days_per_quarter == days_per_quarter
     assert attsim.fm.days_per_quarter == days_per_quarter
+
+    data = attsim.data()
+
+    assert len(data["prices"]) == 30

--- a/simulate/run_any_simulation.py
+++ b/simulate/run_any_simulation.py
@@ -67,7 +67,7 @@ parser.add_argument('--d2', help='FinanceModel: memory parameter d2', default=60
 # Chum parameters
 parser.add_argument('--buysize', help='Chum: buy size to shock', default=0)
 parser.add_argument('--sellsize', help='Chum: sell size to shock', default=0)
-parser.add_argument('--pad', help='Chum: number of days to pad market', default=31)
+parser.add_argument('--pad', help='Nmber of days to burn in the market', default=None)
 
 
 timestamp_start = datetime.now().strftime("%Y-%b-%d_%H:%M")
@@ -104,7 +104,8 @@ def run_attention_simulation(
     p2 = 0.1,
     d1 = 60,
     d2 = 60,
-    rng = None
+    rng = None,
+    pad = None
     ):
 
     # initialize population
@@ -118,7 +119,7 @@ def run_attention_simulation(
     sim = AttentionSimulation(
         pop, FinanceModel, a = a, q = q, r = r, market = market, rng = rng)
     
-    sim.simulate()
+    sim.simulate(burn_in = pad)
 
     return sim.data(), sim.sim_stats(), sim.history
 
@@ -184,7 +185,7 @@ if __name__ == '__main__':
     ## Chum parameters
     buysize = int(args.buysize)
     sellsize = int(args.sellsize)
-    pad = int(args.pad) - 1
+    pad = int(args.pad) - 1 if args.pad is not None else None
 
 
     print(" ".join([str(x) for x in [
@@ -245,7 +246,8 @@ if __name__ == '__main__':
             p2 = p2,
             d1 = d1,
             d2 = d2,
-            rng = rng
+            rng = rng,
+            pad = pad
         )
     elif args.simulation == 'Calibration':
         data, sim_stats, history = run_chum_simulation(

--- a/simulate/run_any_simulation.py
+++ b/simulate/run_any_simulation.py
@@ -145,7 +145,7 @@ def run_chum_simulation(
 
     sim = CalibrationSimulation(pop, FinanceModel, a = a, q = q, r = r, market = market)
     
-    sim.simulate(pad, buy_sell_shock=(buy, sell))
+    sim.simulate(burn_in=pad, buy_sell_shock=(buy, sell))
 
     return sim.data(), {}, sim.history
 


### PR DESCRIPTION
Addresses #122 by functionalizing out the burn-in period from Chum into a method for all simulations, and working this through Calibration and Attention simulations.

A couple open questions about this:
 - What to do about the dividend process during burn-in? Chum let it walk normally.
 - There are inconsistencies in how Chum and AttentionSimulation have been doing tracking slightly differently. Currently, there are errors when using the burn_in when doing the AttentionSimulation because of these discrepancies. Fixing these is issue #81.

The upshot is I need to talk to @mesalas and @gms158 because this change will effect downstream data output (and aggregation scripts) as well as upstream market behavior.