### PR TITLE
WIP: AdaptiveExpectations : Usual/Strange regimes

### DIFF
--- a/sharkfin/expectations.py
+++ b/sharkfin/expectations.py
@@ -387,7 +387,7 @@ class AdaptiveExpectations(FinanceModel):
 
         try:
             # weird hard-coded value that does influence the zeta / p threshold.
-            ksd = ks_1samp(strange_dist.rvs(100), usual_dist.cdf)
+            ksd = ks_1samp(strange_dist.rvs(10), usual_dist.cdf)
         except Exception as e:
             print(f"strange_ror: {strange_ror}, strange_std: {strange_std}")
             print(strange_dist.kwds)
@@ -395,9 +395,11 @@ class AdaptiveExpectations(FinanceModel):
             raise e
 
         if ksd.pvalue > self.zeta:
+            print(f"USUAL: p: {ksd.pvalue} > zeta = {self.zeta}")
             ror = usual_ror
             std = usual_std
         else:
+            print(f"STRANGE: p: {ksd.pvalue} <= zeta = {self.zeta}")
             ror = strange_ror
             std = strange_std
 

--- a/sharkfin/simulation.py
+++ b/sharkfin/simulation.py
@@ -335,7 +335,7 @@ class MarketSimulation(AbstractSimulation):
         sim_stats['dividend_std'] = self.market.dividend_std
 
         sim_stats['seconds'] = (self.end_time - self.start_time).seconds
-        sim_stats['end_da y'] = self.end_day
+        sim_stats['end_day'] = self.end_day
 
         try:
             clean_log_returns = [r for r in self.market.log_return_list() if not np.isnan(r)]

--- a/sharkfin/simulation.py
+++ b/sharkfin/simulation.py
@@ -335,16 +335,19 @@ class MarketSimulation(AbstractSimulation):
         sim_stats['dividend_std'] = self.market.dividend_std
 
         sim_stats['seconds'] = (self.end_time - self.start_time).seconds
-        sim_stats['end_day'] = self.end_day
+        sim_stats['end_da y'] = self.end_day
 
         try:
             clean_log_returns = [r for r in self.market.log_return_list() if not np.isnan(r)]
 
             # stylized facts
-            sim_stats['log_return_autocorrelation'] = stylized_facts.DW_test(
+            sim_stats['log_return_autocorrelation_DW'] = stylized_facts.DW_test(
                 np.array([r for r in clean_log_returns])) - 2
-            sim_stats['log_return_squared_autocorrelation'] = stylized_facts.DW_test(
+            sim_stats['log_return_squared_autocorrelation_DW'] = stylized_facts.DW_test(
                 np.array([r ** 2 for r in clean_log_returns])) - 2
+
+            # TODO: Include less confusing autocorrelation values
+            # Maybe https://www.statsmodels.org/stable/generated/statsmodels.tsa.stattools.acf.html
         except Exception as e:
             print("Problem computing stylized facts")
             print(e)

--- a/sharkfin/simulation.py
+++ b/sharkfin/simulation.py
@@ -409,7 +409,7 @@ class MacroSimulation(MarketSimulation):
         self.fm = Fm(
             self.market,
             days_per_quarter = self.days_per_quarter,
-            **fm_args
+            options = fm_args
             )
         self.fm.calculate_risky_expectations()
 
@@ -662,10 +662,7 @@ class MacroSimulation(MarketSimulation):
         sim_stats['total_population_aLvl_mean'] = total_pop_aLvl_mean
         sim_stats['total_population_aLvl_std'] = total_pop_aLvl_std
 
-        sim_stats['p1'] = self.fm.p1
-        sim_stats['p2'] = self.fm.p2
-        sim_stats['delta_t1'] = self.fm.delta_t1
-        sim_stats['delta_t2'] = self.fm.delta_t2
+        sim_stats.update(self.fm.options)
         sim_stats['dollars_per_hark_money_unit'] = self.pop.dollars_per_hark_money_unit
         
         return sim_stats

--- a/sharkfin/stylized_facts.py
+++ b/sharkfin/stylized_facts.py
@@ -52,7 +52,10 @@ def DW_test(x): # Durbin Watson test
     """
     DW_test(x)
 
-    Perform the Durbin-Watson test for a one-dimensional numpy array (x). 
+    Perform the Durbin-Watson test for a one-dimensional numpy array (x).
+
+    TODO: Consider replacing with
+    https://www.statsmodels.org/dev/generated/statsmodels.stats.stattools.durbin_watson.html
 
     """
 

--- a/sharkfin/tests/test_expectations.py
+++ b/sharkfin/tests/test_expectations.py
@@ -1,4 +1,4 @@
-from sharkfin.expectations import FinanceModel
+from sharkfin.expectations import FinanceModel, UsualExpectations
 from sharkfin.markets import MockMarket
 
 
@@ -38,3 +38,38 @@ def test_FinanceModel():
     assert len(ror1) != len(ror2)
     assert len(estd1) != len(estd2)
     assert a != b
+
+def test_UsualExpectations():
+    fm = UsualExpectations(MockMarket(), days_per_quarter = 30)
+
+    fm.market.run_market()
+    fm.calculate_risky_expectations()
+
+    fm.market.run_market()
+    fm.calculate_risky_expectations()
+
+    a = fm.risky_expectations()
+
+    ror1 = fm.market.ror_list()
+    estd1 = fm.expected_std_list.copy()
+
+    fm.market.run_market()
+    fm.calculate_risky_expectations()
+    
+    fm.market.run_market()
+    fm.calculate_risky_expectations()
+
+    fm.market.run_market()
+    fm.calculate_risky_expectations()
+
+    fm.market.run_market()
+    fm.calculate_risky_expectations()
+
+    b = fm.risky_expectations()
+    
+    ror2 = fm.market.ror_list()
+    estd2 = fm.expected_std_list.copy()
+
+    assert len(ror1) != len(ror2)
+    assert len(estd1) != len(estd2)
+    assert a == b

--- a/simulate/run_any_simulation.py
+++ b/simulate/run_any_simulation.py
@@ -23,7 +23,7 @@ from sharkfin.markets import MockMarket
 from sharkfin.markets.ammps import ClientRPCMarket
 from sharkfin.population import AgentPopulation
 from sharkfin.simulation import AttentionSimulation, CalibrationSimulation
-from sharkfin.expectations import FinanceModel, UsualExpectations
+from sharkfin.expectations import AdaptiveExpectations, FinanceModel, UsualExpectations
 
 
 class NpEncoder(json.JSONEncoder):
@@ -72,7 +72,10 @@ parser.add_argument('-q', '--queue', help='RabbitMQ: name of rabbitmq queue', de
 parser.add_argument('-r', '--rhost', help='RabbitMQ: rabbitmq server location', default='localhost')
 
 # Expectations module
-parser.add_argument('--expectations', help='Expectations: name of Expectations class. Options: FinanceModel, UsualExpectations', default = "FinanceModel")
+parser.add_argument('--expectations',
+    help='Expectations: name of Expectations class. Options: FinanceModel, UsualExpectations, AdaptiveExpectations',
+    default = "FinanceModel"
+    )
 
 # Memory-based FinanceModel arguments
 parser.add_argument('--p1', help='FinanceModel: memory parameter p1', default=0.1)
@@ -269,6 +272,8 @@ if __name__ == '__main__':
         expectations_class = FinanceModel
     elif expectations_class_name == "UsualExpectations":
         expectations_class = UsualExpectations
+    elif expectations_class_name == "AdaptiveExpectations":
+        expectations_class = AdaptiveExpectations
     else:
         print(f"{expectations_class_name} is not a known Expectations class. Using UsualExpectations.")
         expectations_class = UsualExpectations

--- a/simulate/run_any_simulation.py
+++ b/simulate/run_any_simulation.py
@@ -83,6 +83,9 @@ parser.add_argument('--p2', help='FinanceModel: memory parameter p2', default=0.
 parser.add_argument('--d1', help='FinanceModel: memory parameter d1', default=60)
 parser.add_argument('--d2', help='FinanceModel: memory parameter d2', default=60)
 
+# AdaptiveExpectations parameters
+parser.add_argument('--zeta', help='AdaptiveExpectations: sensitivity parameter. 0.0 <= zeta <= 1.0', default=0.5)
+
 # Chum parameters
 parser.add_argument('--buysize', help='Chum: buy size to shock', default=0)
 parser.add_argument('--sellsize', help='Chum: sell size to shock', default=0)
@@ -124,6 +127,7 @@ def run_attention_simulation(
     p2 = 0.1,
     d1 = 60,
     d2 = 60,
+    zeta = 0.5,
     rng = None,
     pad = None,
     seed = None
@@ -143,7 +147,8 @@ def run_attention_simulation(
             'p1' : p1,
             'p2' : p2,
             'delta_t1' : d1,
-            'delta_t2' : d2
+            'delta_t2' : d2,
+            'zeta' : zeta
         })
     
     sim.simulate(burn_in = pad)
@@ -211,6 +216,9 @@ if __name__ == '__main__':
     d1 = float(args.d1)
     d2 = float(args.d2)
 
+    # AdaptiveExpectations argument
+    zeta = float(args.zeta)
+
     # Specific to RabbitMQ AMMPS Market 
     host = args.rhost
     queue = args.queue
@@ -238,6 +246,7 @@ if __name__ == '__main__':
         p2,
         d1,
         d2,
+        zeta,
         buysize,
         sellsize,
         pad
@@ -293,6 +302,7 @@ if __name__ == '__main__':
             p2 = p2,
             d1 = d1,
             d2 = d2,
+            zeta = zeta,
             rng = rng,
             pad = pad,
             seed = seed


### PR DESCRIPTION
As per #60 

Introduces AdaptiveExpectations class which extends the FinanceModel with:
 - 'usual' expectations
 - when 'risky_expectations()' is called to inform an agent, it stochastically tests whether the finance model expectations are sufficiently distant (via Kolmogorov-Smirnov test) from the Usual expectations. If not, usual expectations are transmitted instead of the FinanceModel expectations.
 - A parameter zeta that thresholds how different the FinanceModel predictions must be to break from usual.

This now can be used with the `run_any_simulation` script with the command line argument `--expectations AdaptiveExpectations`. But:
 - I have not yet exposed the `zeta` parameter properly to that script. 
 - Nor have I made it so the simulation calibrates the usual expectations to the dividend process.

So this needs some more work, including testing, before merging.